### PR TITLE
Use purescript-options instead of option records

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,8 @@
     "purescript-argonaut-codecs": "^1.1.0",
     "purescript-unsafe-coerce": "^1.0.0",
     "purescript-partial": "^1.1.2",
-    "purescript-exceptions": "~1.0.0"
+    "purescript-exceptions": "~1.0.0",
+    "purescript-options": "^1.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^1.0.0"

--- a/docs/Screeps/Creep.md
+++ b/docs/Screeps/Creep.md
@@ -17,13 +17,85 @@ type BodyPart = { boost :: Maybe String, type :: BodyPartType, hits :: Int }
 #### `MoveOptions`
 
 ``` purescript
-type MoveOptions = PathOptions (reusePath :: Maybe Int, serializeMemory :: Maybe Boolean, noPathFinding :: Maybe Boolean)
+data MoveOptions :: *
 ```
 
-#### `moveOpts`
+#### `MoveOption`
 
 ``` purescript
-moveOpts :: MoveOptions
+type MoveOption = Option MoveOptions
+```
+
+#### `ignoreCreeps`
+
+``` purescript
+ignoreCreeps :: MoveOption Boolean
+```
+
+#### `ignoreDestructibleStructures`
+
+``` purescript
+ignoreDestructibleStructures :: MoveOption Boolean
+```
+
+#### `ignoreRoads`
+
+``` purescript
+ignoreRoads :: MoveOption Boolean
+```
+
+#### `ignore`
+
+``` purescript
+ignore :: MoveOption (Array RoomPosition)
+```
+
+#### `avoid`
+
+``` purescript
+avoid :: MoveOption (Array RoomPosition)
+```
+
+#### `maxOps`
+
+``` purescript
+maxOps :: MoveOption Int
+```
+
+#### `heuristicWeight`
+
+``` purescript
+heuristicWeight :: MoveOption Number
+```
+
+#### `serialize`
+
+``` purescript
+serialize :: MoveOption Boolean
+```
+
+#### `maxRooms`
+
+``` purescript
+maxRooms :: MoveOption Int
+```
+
+#### `reusePath`
+
+``` purescript
+reusePath :: MoveOption Int
+```
+
+#### `serializeMemory`
+
+``` purescript
+serializeMemory :: MoveOption Boolean
+```
+
+#### `noPathFinding`
+
+``` purescript
+noPathFinding :: MoveOption Boolean
 ```
 
 #### `body`
@@ -233,7 +305,7 @@ moveTo :: forall a e. Creep -> TargetPosition a -> Eff (cmd :: CMD, memory :: ME
 #### `moveTo'`
 
 ``` purescript
-moveTo' :: forall a e. Creep -> TargetPosition a -> MoveOptions -> Eff (cmd :: CMD, memory :: MEMORY | e) ReturnCode
+moveTo' :: forall a e. Creep -> TargetPosition a -> Options MoveOptions -> Eff (cmd :: CMD, memory :: MEMORY | e) ReturnCode
 ```
 
 #### `notifyWhenAttacked`

--- a/docs/Screeps/FFI.md
+++ b/docs/Screeps/FFI.md
@@ -170,22 +170,4 @@ toNullable :: forall a. Maybe a -> NullOrUndefined a
 toUndefinable :: forall a. Maybe a -> NullOrUndefined a
 ```
 
-#### `JsObject`
-
-``` purescript
-data JsObject :: *
-```
-
-#### `selectMaybesImpl`
-
-``` purescript
-selectMaybesImpl :: forall a. (Maybe a -> Boolean) -> (Maybe a -> a) -> a -> JsObject
-```
-
-#### `selectMaybes`
-
-``` purescript
-selectMaybes :: forall a. a -> JsObject
-```
-
 

--- a/docs/Screeps/Room.md
+++ b/docs/Screeps/Room.md
@@ -17,13 +17,67 @@ getRoomGlobal :: forall e. Eff (tick :: TICK | e) RoomGlobal
 #### `PathOptions`
 
 ``` purescript
-type PathOptions o = { ignoreCreeps :: Maybe Boolean, ignoreDestructibleStructures :: Maybe Boolean, ignoreRoads :: Maybe Boolean, ignore :: Maybe (Array RoomPosition), avoid :: Maybe (Array RoomPosition), maxOps :: Maybe Int, heuristicWeight :: Maybe Number, serialize :: Maybe Boolean, maxRooms :: Maybe Int | o }
+data PathOptions :: *
 ```
 
-#### `pathOpts`
+#### `PathOption`
 
 ``` purescript
-pathOpts :: PathOptions ()
+type PathOption = Option PathOptions
+```
+
+#### `ignoreCreeps`
+
+``` purescript
+ignoreCreeps :: PathOption Boolean
+```
+
+#### `ignoreDestructibleStructures`
+
+``` purescript
+ignoreDestructibleStructures :: PathOption Boolean
+```
+
+#### `ignoreRoads`
+
+``` purescript
+ignoreRoads :: PathOption Boolean
+```
+
+#### `ignore`
+
+``` purescript
+ignore :: PathOption (Array RoomPosition)
+```
+
+#### `avoid`
+
+``` purescript
+avoid :: PathOption (Array RoomPosition)
+```
+
+#### `maxOps`
+
+``` purescript
+maxOps :: PathOption Int
+```
+
+#### `heuristicWeight`
+
+``` purescript
+heuristicWeight :: PathOption Number
+```
+
+#### `serialize`
+
+``` purescript
+serialize :: PathOption Boolean
+```
+
+#### `maxRooms`
+
+``` purescript
+maxRooms :: PathOption Int
 ```
 
 #### `controller`
@@ -157,7 +211,7 @@ findPath :: Room -> RoomPosition -> RoomPosition -> Path
 #### `findPath'`
 
 ``` purescript
-findPath' :: forall o. Room -> RoomPosition -> RoomPosition -> PathOptions o -> Path
+findPath' :: Room -> RoomPosition -> RoomPosition -> Options PathOptions -> Path
 ```
 
 #### `getPositionAt`

--- a/docs/Screeps/RoomPosition.md
+++ b/docs/Screeps/RoomPosition.md
@@ -17,7 +17,79 @@ tryPure :: forall a. Eff (err :: EXCEPTION) a -> Either Error a
 #### `ClosestPathOptions`
 
 ``` purescript
-type ClosestPathOptions = PathOptions (filter :: Maybe (forall a. a -> Boolean), algorithm :: Maybe FindAlgorithm)
+data ClosestPathOptions :: *
+```
+
+#### `ClosestPathOption`
+
+``` purescript
+type ClosestPathOption = Option ClosestPathOptions
+```
+
+#### `ignoreCreeps`
+
+``` purescript
+ignoreCreeps :: ClosestPathOption Boolean
+```
+
+#### `ignoreDestructibleStructures`
+
+``` purescript
+ignoreDestructibleStructures :: ClosestPathOption Boolean
+```
+
+#### `ignoreRoads`
+
+``` purescript
+ignoreRoads :: ClosestPathOption Boolean
+```
+
+#### `ignore`
+
+``` purescript
+ignore :: ClosestPathOption (Array RoomPosition)
+```
+
+#### `avoid`
+
+``` purescript
+avoid :: ClosestPathOption (Array RoomPosition)
+```
+
+#### `maxOps`
+
+``` purescript
+maxOps :: ClosestPathOption Int
+```
+
+#### `heuristicWeight`
+
+``` purescript
+heuristicWeight :: ClosestPathOption Number
+```
+
+#### `serialize`
+
+``` purescript
+serialize :: ClosestPathOption Boolean
+```
+
+#### `maxRooms`
+
+``` purescript
+maxRooms :: ClosestPathOption Int
+```
+
+#### `filter`
+
+``` purescript
+filter :: forall a. ClosestPathOption (FilterFn a)
+```
+
+#### `algorithm`
+
+``` purescript
+algorithm :: ClosestPathOption FindAlgorithm
 ```
 
 #### `FindAlgorithm`
@@ -37,12 +109,6 @@ algorithmAstar :: FindAlgorithm
 
 ``` purescript
 algorithmDijkstra :: FindAlgorithm
-```
-
-#### `closestPathOpts`
-
-``` purescript
-closestPathOpts :: ClosestPathOptions
 ```
 
 #### `unwrapContext`
@@ -108,7 +174,7 @@ findClosestByPath :: forall a. RoomPosition -> FindContext a -> Either Error (Ma
 #### `findClosestByPath'`
 
 ``` purescript
-findClosestByPath' :: forall a. RoomPosition -> FindContext a -> ClosestPathOptions -> Either Error (Maybe a)
+findClosestByPath' :: forall a. RoomPosition -> FindContext a -> Options ClosestPathOptions -> Either Error (Maybe a)
 ```
 
 #### `findClosestByRange`
@@ -132,7 +198,7 @@ findInRange :: forall a. RoomPosition -> FindContext a -> Int -> Either Error (A
 #### `findInRange'`
 
 ``` purescript
-findInRange' :: forall a. RoomPosition -> FindContext a -> Int -> FilterFn a -> Either Error (Array a)
+findInRange' :: forall a. RoomPosition -> FindContext a -> Int -> Options PathOptions -> Either Error (Array a)
 ```
 
 #### `findPathTo`
@@ -144,7 +210,7 @@ findPathTo :: forall a. RoomPosition -> TargetPosition a -> Either Error Path
 #### `findPathTo'`
 
 ``` purescript
-findPathTo' :: forall a. RoomPosition -> TargetPosition a -> PathOptions () -> Either Error Path
+findPathTo' :: forall a. RoomPosition -> TargetPosition a -> Options PathOptions -> Either Error Path
 ```
 
 #### `getDirectionTo`

--- a/src/Screeps/FFI.js
+++ b/src/Screeps/FFI.js
@@ -238,20 +238,3 @@ exports.toMaybeImpl = function(val, nothing, just){
         return just(val);
     }
 }
-
-exports.selectMaybesImpl = function(isJust){
-    return function(fromJust){
-        return function(obj){
-            var newObj = {};
-            for(var key in obj){
-                if(!obj.hasOwnProperty(key)){
-                    continue;
-                }
-                if(isJust(obj[key])){
-                    newObj[key] = fromJust(obj[key]);
-                }
-            }
-            return newObj;
-        }
-    }
-}

--- a/src/Screeps/FFI.purs
+++ b/src/Screeps/FFI.purs
@@ -42,9 +42,3 @@ toNullable = maybe null notNullOrUndefined
 
 toUndefinable :: forall a. Maybe a -> NullOrUndefined a
 toUndefinable = maybe undefined notNullOrUndefined
-
-foreign import data JsObject :: *
-foreign import selectMaybesImpl :: forall a. (Maybe a -> Boolean) -> (Maybe a -> a) -> a -> JsObject
-
-selectMaybes :: forall a. a -> JsObject
-selectMaybes obj = unsafePartial $ selectMaybesImpl isJust fromJust obj

--- a/src/Screeps/Room.purs
+++ b/src/Screeps/Room.purs
@@ -8,38 +8,45 @@ import Data.Either (Either(Left,Right))
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.StrMap as StrMap
 import Data.Tuple (Tuple(Tuple))
+import Data.Options (Options, Option, opt, options)
 
 import Screeps.Effects (CMD, TICK)
 import Screeps.Types (Controller, Color, FilterFn, FindType, LookType, Mode, Path, ReturnCode, Room, RoomPosition, Storage, StructureType, TargetPosition(..), Terminal)
-import Screeps.FFI (runThisEffFn1, runThisEffFn2, runThisEffFn3, runThisEffFn4, runThisEffFn5, runThisFn1, runThisFn2, runThisFn3, selectMaybes, toMaybe, unsafeField)
+import Screeps.FFI (runThisEffFn1, runThisEffFn2, runThisEffFn3, runThisEffFn4, runThisEffFn5, runThisFn1, runThisFn2, runThisFn3, toMaybe, unsafeField)
 
 foreign import data RoomGlobal :: *
 foreign import getRoomGlobal :: forall e. Eff (tick :: TICK | e) RoomGlobal
 
 -- TODO: costCallback option
-type PathOptions o =
-  { ignoreCreeps :: Maybe Boolean
-  , ignoreDestructibleStructures :: Maybe Boolean
-  , ignoreRoads :: Maybe Boolean
-  , ignore :: Maybe (Array RoomPosition)
-  , avoid :: Maybe (Array RoomPosition)
-  , maxOps :: Maybe Int
-  , heuristicWeight :: Maybe Number
-  , serialize :: Maybe Boolean
-  , maxRooms :: Maybe Int
-  | o }
+foreign import data PathOptions :: *
+type PathOption = Option PathOptions
 
-pathOpts :: PathOptions ()
-pathOpts =
-  { ignoreCreeps: Nothing
-  , ignoreDestructibleStructures: Nothing
-  , ignoreRoads: Nothing
-  , ignore: Nothing
-  , avoid: Nothing
-  , maxOps: Nothing
-  , heuristicWeight: Nothing
-  , serialize: Nothing
-  , maxRooms: Nothing }
+ignoreCreeps :: PathOption Boolean
+ignoreCreeps = opt "ignoreCreeps"
+
+ignoreDestructibleStructures :: PathOption Boolean
+ignoreDestructibleStructures = opt "ignoreDestructibleStructures"
+
+ignoreRoads :: PathOption Boolean
+ignoreRoads = opt "ignoreRoads"
+
+ignore :: PathOption (Array RoomPosition)
+ignore = opt "ignore"
+
+avoid :: PathOption (Array RoomPosition)
+avoid = opt "avoid"
+
+maxOps :: PathOption Int
+maxOps = opt "maxOps"
+
+heuristicWeight :: PathOption Number
+heuristicWeight = opt "heuristicWeight"
+
+serialize :: PathOption Boolean
+serialize = opt "serialize"
+
+maxRooms :: PathOption Int
+maxRooms = opt "maxRooms"
 
 controller :: Room -> Maybe Controller
 controller room = toMaybe $ unsafeField "controller" room
@@ -121,8 +128,8 @@ findExitTo room (RoomObj otherRoom) = findExitToImpl room otherRoom Left Right
 findPath :: Room -> RoomPosition -> RoomPosition -> Path
 findPath = runThisFn2 "findPath"
 
-findPath' :: forall o. Room -> RoomPosition -> RoomPosition -> PathOptions o -> Path
-findPath' room pos1 pos2 opts = runThisFn3 "findPath" room pos1 pos2 (selectMaybes opts)
+findPath' :: Room -> RoomPosition -> RoomPosition -> Options PathOptions -> Path
+findPath' room pos1 pos2 opts = runThisFn3 "findPath" room pos1 pos2 (options opts)
 
 getPositionAt :: Room -> Int -> Int -> RoomPosition
 getPositionAt = runThisFn2 "getPositionAt"


### PR DESCRIPTION
This should make the handling of option objects nicer, with a more universal purescript interface.

For example, to create options to make the `find'` function in the Room module ignore roads and do max 200 operations, you could specify:

``` purescript
opts :: Options PathOptions
opts = ignoreRoads := true
    <> maxOps := 200
```

and use the `opts` value as the parameter to the `find'` call.
